### PR TITLE
Fix path issue, add support for emulating multiple displays

### DIFF
--- a/software/README.md
+++ b/software/README.md
@@ -22,6 +22,22 @@ roslaunch rover_main ground_station.launch
 
 If the rover is connected and running its appropriate software, the ground station should start up in full screen across both monitors. Live video should be seen in the right hand monitor. Pressing the thumb button on the joystick and then moving the y-axis should cause the wheels on the Rover to turn. If this is working, you’ve set everything up correctly. Ctrl-q will quit the application once desired.
 
+It is also possible to run the groundstation on a computer with only one display by emulating two displays with Xephyr.
+
+Make sure you have Xephyr installed:
+
+```
+sudo apt install xserver-xephyr
+```
+
+From there, run the following command:
+
+```
+roslaunch rover_main ground_station_single_screen.launch  
+```
+
+This will launch the groundstation within the emulated displays. The emulated displays will appears as windows.
+
 
 ## Making Changes
 

--- a/software/ground_station_setup.sh
+++ b/software/ground_station_setup.sh
@@ -26,7 +26,7 @@ catkin_workspace_path="$HOME/$catkin_workspace_dir"
 catkin_src_path="$catkin_workspace_path/src"
 
 # Get the rover software directory
-github_rover_repo_dir="Github/Rover_2019_2020"
+github_rover_repo_dir="Github/Rover_2020_2021"
 github_rover_packages_path="$HOME/$github_rover_repo_dir/software/ros_packages"
 
 # Remove existing symbolic links if necessary

--- a/software/ros_packages/ground_station/scripts/ground_station_single_screen_launch.sh
+++ b/software/ros_packages/ground_station/scripts/ground_station_single_screen_launch.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+current_folder_name="scripts"
+current_folder_name_length=`expr length $current_folder_name`
+
+launch_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+launch_dir_length=`expr length $launch_dir`
+
+launch_dir_length_without_current_folder=$(($launch_dir_length-$current_folder_name_length))
+
+script_launch_path="${launch_dir:0:$launch_dir_length_without_current_folder}/src"
+cd $script_launch_path
+
+cp ~/key .
+
+sleep 1
+
+# there needs to be an initial display value
+export DISPLAY=:0
+# launch Xephyr in background to emulate two 1920x1080 displays
+Xephyr +xinerama -screen 1920x1080 -screen 1920x1080 -ac :1 &
+# change the display variable to allow connecting to Xephyr
+export DISPLAY=:1
+
+python ground_station.py

--- a/software/ros_packages/rover_arm_ik/rover_arm_control/CMakeLists.txt
+++ b/software/ros_packages/rover_arm_ik/rover_arm_control/CMakeLists.txt
@@ -1,0 +1,94 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(rover_arm_control)
+
+## Add flag for c++11
+add_compile_options(-std=c++11)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS
+  hardware_interface
+  controller_manager
+  actionlib
+  control_msgs
+  roscpp
+  sensor_msgs
+  std_msgs
+  trajectory_msgs
+  tf
+)
+
+## System dependencies are found with CMake's conventions
+find_package(Boost REQUIRED COMPONENTS system)
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if you package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES arm_hw_interface
+  CATKIN_DEPENDS hardware_interface controller_manager actionlib control_msgs roscpp trajectory_msgs
+#  DEPENDS arm_hw_interface
+)
+
+###########
+## Build ##
+###########
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+include_directories(include
+  ${catkin_INCLUDE_DIRS}
+)
+
+## Declare a C++ library
+
+# Hardware Interface
+add_library(arm_hw_interface arm_hw_interface/arm_hw_interface.cpp)
+target_link_libraries(arm_hw_interface
+  ${catkin_LIBRARIES}
+  simplemotion2
+)
+
+## Specifying sources
+set(${PROJECT_NAME}_SOURCES
+  arm_hw_interface/arm_state.cpp
+  arm_hw_interface/arm_hw_interface.cpp)
+
+
+## Declare a C++ executable
+add_executable(arm_hw_interface_node ${${PROJECT_NAME}_SOURCES})
+
+## Add dependencies
+add_dependencies(arm_hw_interface_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Specify libraries to link a library or executable target against
+target_link_libraries(arm_hw_interface_node
+  arm_hw_interface
+  ${catkin_LIBRARIES}
+)
+
+#############
+## Install ##
+#############
+
+install(DIRECTORY launch/ DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch)
+install(DIRECTORY config/ DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/config)
+
+## Mark executables and/or libraries for installation
+install(TARGETS arm_hw_interface arm_hw_interface_node
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+## Mark cpp header files for installation
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h"
+)

--- a/software/ros_packages/rover_arm_ik/rover_arm_control/CMakeLists.txt
+++ b/software/ros_packages/rover_arm_ik/rover_arm_control/CMakeLists.txt
@@ -59,7 +59,8 @@ target_link_libraries(arm_hw_interface
 ## Specifying sources
 set(${PROJECT_NAME}_SOURCES
   arm_hw_interface/arm_state.cpp
-  arm_hw_interface/arm_hw_interface.cpp)
+  arm_hw_interface/arm_hw_interface.cpp
+  arm_hw_interface/arm_hw_interface_node.cpp)
 
 
 ## Declare a C++ executable

--- a/software/ros_packages/rover_main/launch/ground_station_single_screen.launch
+++ b/software/ros_packages/rover_main/launch/ground_station_single_screen.launch
@@ -1,0 +1,8 @@
+<launch>
+    <!-- ########## Start Nimbro Topic Transport Nodes ########## -->
+    <include file="$(find rover_main)/launch/ground_station/topic_transport_senders.launch"/>
+    <include file="$(find rover_main)/launch/ground_station/topic_transport_receivers.launch"/>
+
+    <!-- ########## Start Ground Station Interface ########## -->
+    <node name="ground_station_single_screen" pkg="ground_station" type="ground_station_single_screen_launch.sh" required="true" output="screen"/>
+</launch>


### PR DESCRIPTION
There was a path in the groundstation setup script that resulted in symlinks to last year's project path being generated instead of symlinks to the current path. This change corrects that.